### PR TITLE
resolve missing package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ruby:2.3
 
-RUN apt-get update -qq && apt-get install -y build-essential git nodejs mysql-client libmysqlclient-dev
+RUN apt-get update -qq && apt-get install -y build-essential git nodejs mysql-client default-libmysqlclient-dev
 
 ENV APP_HOME /app
 RUN mkdir $APP_HOME


### PR DESCRIPTION
```
Building dependency tree...

Reading state information...

Package libmysqlclient-dev is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source


[91mE: Package 'libmysqlclient-dev' has no installation candidate
```